### PR TITLE
Initial checkin of Services Documentation templates.

### DIFF
--- a/service_docs/README.md
+++ b/service_docs/README.md
@@ -1,0 +1,113 @@
+# Templates for Services Documentation
+
+(The "ops100" docs.)
+
+The `templates` directory contains the following templates:
+
+-   [index.md](templates/index.md)
+-   [operations.md](templates/operations.md)
+-   [build.md](templates/build.md)
+-   [disaster\_recovery.md](templates/disaster_recovery.md)
+-   [common\_tasks.md](templates/common_tasks.md)
+-   [security.md](templates/security.md)
+
+The `index.md` file is a template for the landing page that should be in each
+service's directory.
+
+The `operations.md` file is intended as a quick overview and holding page for
+basic facts about the service as well as the basic troubleshooting guide for
+oncall (since they will need the basic facts as well).
+
+The `build.md` file contains instructions for building functioning instances for
+with the service. Ideally you should provide step-by-step instructions that
+someone else could follow to recreate the server and service. The `build.md`
+template provides an outline structure to issues you should remember to cover,
+but you may format this document as is most appropriate for your service. Some
+services may like to describe their *infrastructure as code* location and
+release+deployment automation instead.
+
+The `disaster_recovery.md` template provides instructions on how to rebuild and
+restore a service in the event of catastrophic failure.
+
+The `common_tasks.md` template provides instructions for helpdesk, onduty,
+security operations, and end users who support or use the service. It also
+provides escalation information.
+
+The `disaster.md` template asks a series of questions regarding the reliability
+of a service, and the impact caused by loss of that service. This document can
+be used in a proactive way during the design and implementation phase of a
+service or after the fact as a way of evaluating how the service will fair in
+various scenarios. (This may or may not be used in the future and is not
+currently linked from the template navigation.)
+
+The `security.md` template describes access control and authorisation mechanisms
+required by the service.
+
+## Motivation
+
+A common structure of documentation helps prompt service owners to document what
+others might need to know but the owner doesn't know that they don't know. In
+other words, it helps operations teams mature by turning tribal knowledge into
+useful documentation.
+
+Another benefit of a common structure is that it lowers the cognitive burden of
+a context switch for oncall and onduty (or interrupts) staff when moving between
+services while debugging dependency chains. It also lowers the ramp-up time for
+people transitioning between teams.
+
+The contents of these docs should be reviewed and changed regularly as the
+service evolves and matures, and as new team members join and are encouraged to
+update the docs as they learn where they've become incorrect. However try to
+keep highly dynamic details out of these documents, like 6 month plans and
+feature roadmaps, especially if that information is already hosted elsewhere --
+hyperlinks are better than manually synchronising content.
+
+## Caution
+
+It may happen that while filling out the templates, one is motivated to describe
+what should be, rather than what is. While a
+[*Production Readiness Review*](https://sre.google/sre-book/evolving-sre-engagement-model/)
+may ask similar questions, this is not a PRR: make sure you document the system
+as built, as that is most useful for the pople who are maintaining the service
+or responding to incidents. (But, do file feature requests for any ideas you
+have to improve the reliability and operational maturity of the service as you
+think of them!)
+
+## Usage
+
+1.  Copy all of the templates to the canonical location for your service
+    documentation.
+
+    This might be in a central location in a monorepo, subdivided by common
+    service name (e.g. /docs/operations/ldap, /docs/operations/ntp) or in a
+    common subdirectory name in each project repo. Crucially everyone should be
+    able to develop muscle memory for the location of the service docs, and find
+    identical structure.
+
+    -   Add a link to yuor new index page to the central index of services.
+
+2.  Replace all strings marked in **@** (e.g. `@SERVICE_NAME@`) with the correct
+    values for your service.
+
+    Embrace sed:
+
+    ```
+    sed -i -e 's/@SERVICE_NAME@/ntp/g' \
+           -e 's/@TICKET_URL@/some_url/g' \
+           -e 's/@DESIGN_URL@/www.designdoc.com/g' \
+           *.md
+    ```
+
+3.  Replace the blockquote instructions with the content they describe.
+
+    -   Try to use the headings provided whenever possible as consistency
+        between documents lowers the burden of a context switch.
+
+    -   Don't feel obliged to fill in all headings if they are not relevant, but
+        if the answer is unknown, leave blank and come back to it later.
+
+    -   You might find you want to add additional documents, which is OK, just
+        update the navigation links.
+
+    -   Change the names of "Ops, Helpdesk, or Security" to match your
+        organisation.

--- a/service_docs/templates/build.md
+++ b/service_docs/templates/build.md
@@ -1,0 +1,176 @@
+[Home](index.md) [Operations](operations.md) [Build](build.md) [DR](disaster_recovery.md) [Common Tasks](common_tasks.md) [Security](security.md)
+
+Last Update: @Date@
+
+> Replace this note with your own customisation.
+
+**Note:** This document is meant for Ops, Helpdesk, or Security. If you are
+having problems with a service, please call Helpdesk or
+[file a ticket](@TICKET_URL@).
+
+@SERVICE_NAME@ Build Document
+=================================
+
+##### Quick links:
+
+-   [Server locations](operations.md#servers_hardware)
+-   [Outage Impact/SLA](index.md#outageimpact)
+
+------------------------------------------------------------------------
+
+This document gives instructions on how to build a new instance of this
+service. Its intended audience is sysadmins who may not be familiar with
+the service.
+
+Build Prerequisites
+-------------------
+
+> What hardware, software, and networking infrastructure that should be in
+> place before you attempt to install the service application?
+> Prerequisites include basic hardware setup, or virual machine type, and the installation of
+> commonly-used supporting software packages, such as Apache.
+
+### Hardware Requirements {#hardware_requirements}
+
+> What server or other hardware is required for this service? How is it
+> obtained, are there spares available? Is this service on console and/or
+> remote power? If not, why not?
+> If the hardware is virtual, explain what footprint is required.  If the service is cloud-native, what's a minimum footprint look like, and on what "as a service" is it on?
+
+#### Physical Location {#location}
+
+> Are there any constraints on what data center(s) or server room(s) this
+> service should be installed in? How do you determine what power circuit
+> it should be connected to? (This may differ if you are setting up a
+> replacement server for a dead box vs. an additional server in a pool.)
+> Provide a link to a list of [current servers and their
+> locations](operations.md#servers_hardware).
+
+> For cloud environments, are there any policy constraints on where the service can be deployed?
+
+### Software Requirements {#software_requirements}
+
+#### OS
+
+> What OS should be installed and what is the procedure?
+> Does a human install Windows 2003 from CD?  Do you PXE-boot Debian from the network?  Do you boot a VM image?
+
+#### Third Party Software
+
+> List all software dependencies.
+> Do we use OS packages or fetch them directly from the upstream maintainers?
+> Do we fork the source and maintain our own branch?
+> Are customizations beyond the default install needed for this service?
+
+
+#### Licenses and Keys
+
+> Are there any licenses or keys that need to be obtained in order to run the
+> service? If so, where do you get them? Are they stored by Security, or do you
+> fetch them from a cloud key store?
+
+### Networking Requirements {#network_requirements}
+
+#### Setting up file shares
+
+> Does the service require you to set up NFS shares? If so, provide the
+> details.
+
+#### Configuring the IP/Subnet/vlan/VIPs
+
+> How should the IP of this service be determined (can it reuse the IP if this
+> is a replacement for a dead server? What if this is an additional server?). DO
+> we have a planning spreadsheet? Does the IP get handed out by DHCP, or do you
+> need to ask the Czar of Naming? What subnet should this service be installed
+> in? What switch should it be connected to? Is it behind a VIP, if so, how is
+> this configured?
+
+#### Configuring Access Control (ACLs/Security Operations)
+
+> Are there network access issues: do routes, acls or firewall rules need to be
+> configured?
+
+For information on access controls and processes to grant them see the
+[security document](security.md).
+
+#### DNS
+
+> What DNS entries need to be configured?  Where?
+
+### Global Replication {#global_replication}
+
+For information on how this service is replicated
+see the [operational document](operations.md#global_replication).
+
+Build Procedure {#build_procedure}
+---------------
+
+> This section should contain a step-by-step procedure for installing the
+> service. Installation of hardware and commonly used supporting software
+> packages should be placed in the Build prerequisite section, if that makes sense to do so.
+
+> Bonus points for linking to the "infrastructure as code" source tree and explaining the automated build.
+
+### Installing the Supporting Software {#supporting_software}
+
+> What packages need to be installed? Are there customizations beyond the
+> default install needed? Do they need to be checked in to p4? Are
+> licenses needed? How do you obtain them?
+
+> Bonus points for linking to the "infrastructure as code" source tree and explaining the automated build.
+
+### Connecting to Other Services {#connecting_to_other_services}
+
+> Which other services does this one need to connect to? What information
+> does it need to get from these services?
+
+### Starting the Service {#starting_the_service}
+
+For instructions on how to start the service, see the [operational document](operations.md#start_stop).
+
+### Testing the Service {#testing_the_service}
+
+For instructions on how to verify if the service is running, see the [operational document](operations.md#service_verify).
+
+### Setting Up Service Monitoring {#setting_up_monitoring}
+
+> Is there local monitoring that needs to be installed/configured/started?
+> Do we need to configure a monitoring service to collect or receive instrumentation?
+
+For a list of current service monitoring, see the [operational document](operations.md#monitoring).
+
+### Setting Up Backups {#setting_up_backups}
+
+> How is the service backed up? What needs to be done to set up the
+> backups?
+
+### Required Notifications or Other Issues {#required_notifications}
+
+> Any other build issues? Is notification required when new servers or
+> replacement servers are installed? Whom should be notified and for
+> non-urgent changes, how much notice should be given? Are there any
+> change management processes/email addresses that need to notified with
+> information about this build?
+
+Adding a Server to the Service {#adding_a_server}
+------------------------------
+
+> Provide step-by-step instructions for adding a server to the service.
+
+Roles {#roles}
+-----------
+
+> If using a configuration management tool like Slack or Puppet, provide the
+> roles and descriptions here.
+>
+> Role Subrole Decription
+>
+> ------------------------------------------------------------------------------
+>
+>      
+
+In-House Build Instructions {#package_build_instructions}
+--------------------------
+
+> If there is custom built software for this
+> service, document its build and release process here.

--- a/service_docs/templates/common_tasks.md
+++ b/service_docs/templates/common_tasks.md
@@ -1,0 +1,72 @@
+[Home](index.md) [Operations](operations.md) [Build](build.md) [DR](disaster_recovery.md) [Common Tasks](common_tasks.md) [Security](security.md)
+
+Last Update: @Date@
+
+> Replace this note with your own customisation.
+
+**Note:** This document is meant for Ops, Helpdesk, or Security. If you are
+having problems with a service, please call Helpdesk or
+[file a ticket](@TICKET_URL@).
+
+@SERVICE_NAME@ Common Tasks
+===============================
+
+##### Quick links:
+
+-   [Server locations](oeprations.md#servers_hardware)
+-   [Outage Impact/SLA](index.md#outageimpact)
+
+
+------------------------------------------------------------------------
+
+This document describes how to perform routine administrative tasks for this
+service. Its intended audience includes onduty, helpdeskers and security
+engineers --- people other than the primary owners who may be asked to perform
+administrative tasks for this service.
+
+Escalation
+----------
+
+> For information on how to route tickets for common issues concerning
+> this service, link to the escalation wiki. You should create an entry in
+> the table for your service, and log common issues there. To create an
+> entry, just copy the the test heading and edit table, and customize them
+> for your service.
+
+Helpdesk
+--------
+
+> What tasks do helpdesk personnel need to perform? Please provide
+> step-by-step instructions for these tasks. Link to an FAQ, if
+> appropriate.
+
+Onduty
+------
+
+> What tasks do onduty personnel need to perform to support this service?
+> Please provide step-by-step instructions for these tasks. Link to an
+> FAQ, if appropriate.
+
+## Security
+
+> What tasks do Security personnel need to perform to support this service?
+> Please provide step-by-step instructions for these tasks. Link to an FAQ, if
+> appropriate.
+
+End User {#end_user}
+--------
+
+> What tasks do end users need to perform to use this service? Please
+> provide links to the relevant helpdesk documentation. If the helpdesk
+> documentation is not up-to-date or complete, file a docbug and help us
+> fix it. Link to an FAQ, if appropriate.
+
+Obtaining Approval {#approval}
+------------------
+
+> There are certain system tasks that require approval by by the service owner
+> or by Security. Please list them in the following approval matrix.
+
+  Task   Approval Needed
+  ------ -----------------
+          

--- a/service_docs/templates/disaster_recovery.md
+++ b/service_docs/templates/disaster_recovery.md
@@ -1,0 +1,95 @@
+[Home](index.md) [Operations](operations.md) [Build](build.md) [DR](disaster_recovery.md) [Common Tasks](common_tasks.md) [Security](security.md)
+
+Last Update: @Date@
+
+> Replace this note with your own customisation.
+
+**Note:** This document is meant for Ops, Helpdesk, or Security. If you are
+having problems with a service, please call Helpdesk or
+[file a ticket](@TICKET_URL@).
+
+@SERVICE_NAME@ Disaster Recovery Instructions
+=================================================
+
+##### Quick links:
+
+-   [Server locations](operations.md#servers_hardware)
+-   [Troubleshooting information](operations.md#troubleshooting)
+-   [Monitoring](operations.md#monitoring)
+-   [Outage Impact/SLA](index.md#outageimpact)
+
+------------------------------------------------------------------------
+
+This document gives instructions on how recover this service in the
+event of a catastrophic failure. Its intended audience is sysadmins who
+may not be familiar with the service.
+
+> For this disaster recovery document, assume a worst-case scenario in
+> which an entire office or datacenter has been lost.
+
+Overview
+--------
+
+> What redundancy is there, what\'s automated, what isn\'t and where is
+> the procedure documented, are there plans to improve the recoverability?
+> Is unique data is associated with this service? How is it backed
+> up/restored? For an overview of the disaster recovery process for this
+> service, see the [service-level document](index.md#disaster_recovery).
+
+### Dependencies
+
+> What services or systems depend on this one? Link to [Outage
+> Impact/SLA](index.md#outageimpact) if appropriate. What other services
+> must be running before this service can be brought up? List all known
+> dependencies, including services like corp network, ldap, kerberos, etc.
+> as required.
+
+Failover
+--------
+
+> Describe the specifics of the failover strategy for this service. If
+> there are hot spares, warm spares, or cold spares, where are they
+> located? Is the failover fully automated?
+
+### Automated Failover Description {#automated_failover}
+
+> Describe in general terms what happens when failover occurs. What
+> triggers the failover? What happens then? Give specific script or file
+> locations as appropriate.
+
+### Manual Failover Tasks {#manual_failover}
+
+> What failover tasks need to be done manually? For each task, give
+> complete, step-by-step instructions in subsections here.
+
+Data
+----
+
+> Does this service have any important local data that needs to be backed
+> up? What is the data? What is the impact if this data is lost? Link to
+> [Outage Impact/SLA](index.md#outageimpact) if appropriate.
+
+### Backups
+
+> What is the backup mechanism and frequency? What directories are backed up,
+> how frequently, by what scripts or procedures, to what locations? What server
+> or servers run the backups? If the backups are stored to tape, where are the
+> tapes stored? If offsite, do we need to borrow the keys to the pink Vespa to
+> get there? (Link to standard backup documentation if available, then identify
+> what is different for this service.)
+
+### Restore Instructions {#restore_instructions}
+
+> If service data needs to be restored from backup, how do you obtain and
+> restore the data? Provide step-by-step instructions here. Link to
+> supporting docs if needed.
+
+Rebuilding the Service {#rebuilding_the_service}
+----------------------
+
+> If you need to completely rebuild the service in the event of
+> catastrophic failure, how do you do that? For example, what kind of
+> hardware is required? What software is needed? What configuration is
+> needed? Break the process into high level tasks, and for each task, give
+> step-by-step instructions here. (Link to the [Build Instructions
+> document](build.md) as appropriate.)

--- a/service_docs/templates/index.md
+++ b/service_docs/templates/index.md
@@ -1,0 +1,169 @@
+[Home](index.md) [Operations](operations.md) [Build](build.md) [DR](disaster_recovery.md) [Common Tasks](common_tasks.md) [Security](security.md)
+
+Last Update: @Date@
+
+> Replace this note with your own customisation.
+
+**Note:** This document is meant for Ops, Helpdesk, or Security. If you are
+having problems with a service, please call Helpdesk or
+[file a ticket](@TICKET_URL).
+
+@SERVICE_NAME@
+==================
+
+| Role                                   | Contact            |
+|----------------------------------------|--------------------|
+| Service Team                           | email              |
+| [Primary Owner](link to org directory) |                    |
+| Secondary Owner                        |                    |
+| Manager                                |                    |
+| Product Development                    | team or individual |
+
+
+
+##### Quick links:
+
+>If there is a separate document or database listing the servers running this
+     service, replace this link to
+
+- [Server locations](operations.md\#servers\_hardware)
+
+> If there is a separate troubleshooting guide, replace this link to       point to it.
+
+- [Troubleshooting information](operations.md#troubleshooting)
+
+
+------------------------------------------------------------------------
+
+This document gives a high-level view of the service. It identifies
+service customers, specifies reliability goals, and captures planning
+information. Its intended audience is managers or new sysadmins.
+
+Description
+-----------
+
+> Brief Description of your service
+
+Related Documents {#related_docs}
+-----------------
+
+> Update the links below to point to the correct documentation; append
+> additional links to related documentation; and remove any inapplicable
+> links.
+
+-   [Operational Instructions](operations.md)
+-   [Build Instructions](build.md)
+-   [DR Instructions](disaster_recovery.md)
+-   [Common Tasks](common_tasks.md)
+-   [Design Document](@DESIGN_URL@)
+
+### Related Services {#related_services}
+
+> Also, link to the homepage of services that are related to this one, if
+> applicable.  Upstream dependencies especially, but major clients also acceptable.
+
+Outage Impact {#outageimpact}
+-------------
+
+> How critical is this service and who is affected if it goes down? What
+> other services are affected by an outage in this one? Which core
+> abilities of the company (such as revenue or productivity) are affected
+> by an outage? How many servers are required to meet the basic SLO or SLA for
+> this service? Quantify this whenever possible.
+
+SLA/SLO
+---
+
+> Identify the primary purpose of the service and determine if there are
+> changes to the service level depending on department, site location, network
+> connection speed, and connection type (wireless/remote VPN). Which
+> parties have established and agreed to this service level?
+
+### User Experience/Runtime Latencies {#runtime_latencies}
+
+> What are the acceptable runtime latencies? See the [metrics](#metrics)
+> section for latency metrics.
+
+### Replication/Catchup Latencies {#catchup_latencies}
+
+> Is the service replicated? If the service is replicated, what are the
+> accepable sync catchup latencies for this service?
+
+### Recovery Time Objective (RTO) {#rto}
+
+> How much downtime of this service is acceptable? Are there different
+> levels of acceptable downtime read vs. write access? Are we currently
+> meeting that requirement? Answer these questions with specific time
+> frames: How long should a site stay down if other sites are available
+> for failover? If there is a catastrophic failure, how long should it
+> take for a service rebuild? Describe the service level guarantees you
+> are making from the perspective of the customer and the business problem
+> this service addresses. The service level definition should not assume any specific
+> implementation of service or solution.
+
+### Recovery Point Objective (RPO) {#rpo}
+
+> If the system fails catastrophically and has to be restored from backup,
+> what is the maximum amount of data that is acceptable? Are we currently
+> meeting that requirement? Answer this question with a specific time
+> frame: In the worst case, what is the time to the most recent backup?
+
+### Maintenance Windows {#maintenance_windows}
+
+> Maximum time the service is unavailable for maintenance reasons, and/or
+> timeframes when maintenance is performed. Link to [scheduled manual
+> tasks](operations.md#sched_man_tasks) section, if applicable.
+
+### Expected Level of Support {#support_level}
+
+> Provide details on what it takes to support the service level defined. How many
+> people does it take to support this service, how long should users wait
+> for service requests, what training is required for each user to use the
+> service effectively?
+
+Metrics and Observability
+-------
+
+> What are the golden metrics are captured for this service? Give links to service dashboards (e.g. Grafana, Google Cloud Monitoring) if they exist. Be
+> sure to explain how metrics are used in service level and capacity planning.
+
+> Where does one go to perform adhoc queries about the behaviour of the service?  Do we grep logs, drill down in metrics aggregation consoles, inspect traces?  All the above?  If necessary explain how one goes about getting access to the data.  Leave "common queries" to another document ,for example the [common tasks](common_tasks.md) document or if possible link to source or saved queries in the query tool itself.
+
+Planning {#plan}
+--------
+
+### Capacity Plan {#capacity_plan}
+
+> How is capacity measured, forecasted, and fulfilled?
+
+> If a detailed planning document or spreadsheet for the next 18 months exists, link to that here.
+
+### Global Replication {#global_replication}
+
+> What is the plan for replicating this service? When
+> are new replicas put in place?
+
+For information on how the service is currently replicated
+see the [operational document](operations.md#global_replication).
+
+### Disaster Recovery Overview {#disaster_recovery}
+
+> Is the disaster recovery setup for this service in a satisfactory state?
+> If not, what improvements are planned?
+
+For details of the current disaster recovery process for this service, see
+the [disaster recovery document](disaster_recovery.md).
+
+### Future Enhancements {#enhancements}
+
+> What changes do we see coming down the pike for this system, either for
+> underlying technology or our implementation? What is the expected
+> schedule of these changes?
+
+> Link to a saved search or hotlist in an issue tracker if suitable.
+
+### Legal/Financial Considerations {#legal_financial}
+
+> Is this service in scope for any of the laws we currently track? These
+> laws include the California Privacy Law, HIPAA, and SOX. What are the
+> issues?

--- a/service_docs/templates/operations.md
+++ b/service_docs/templates/operations.md
@@ -1,0 +1,164 @@
+[Home](index.md) [Operations](operations.md) [Build](build.md) [DR](disaster_recovery.md) [Common Tasks](common_tasks.md) [Security](security.md)
+
+Last Update: @Date@
+
+> Replace this note with your own customisation.
+
+**Note:** This document is meant for Ops, Helpdesk, or Security. If you are
+having problems with a service, please call Helpdesk or
+[file a ticket](@TICKET_URL@).
+
+@SERVICE_NAME@ Operational Document
+=======================================
+
+##### Quick links:
+
+-   [Server locations](operations.md#servers_hardware)
+-   [Outage Impact/SLA](index.md#outageimpact)
+
+------------------------------------------------------------------------
+
+This document describes how to operate and maintain the service. Its
+intended audience includes service owners and oncall.
+
+Stop/Start Instructions {#stop_start}
+-----------------------
+
+> Complete instructions on how to stop and start the service and how to
+> confirm it is properly stopped or started. Be sure that you answer the
+> following questions: How do you log in to the server and what privileges
+> do you need? Does monitoring need to be turned off during stop/starts?
+> If only the service owner(s) should be involved in stop/starts, it is
+> appropriate to say so and just provide a link to the detailed service
+> manual document instead (where stop/start instructions should exist).
+
+Troubleshooting
+---------------
+
+### Capturing Debug Information {#debug_information}
+
+> Is there any debug information that should be captured before any
+> attempt is made to restore the system?
+
+### Verification {#service_verify}
+
+> How do you verify that the service is running properly? What processes
+> run normally, how many, and what users do they run as? How can you tell
+> if the system is overloaded? If appropriate, include the following: an
+> edited `ps` output instructions on how to test functionality via
+> application, telnet, and/or command-line how to test that license, if
+> needed, is available
+
+### Hints and Tips {#hints_and_tips}
+
+> What are the common problems and errors seen with this service? How do
+> you handle them? This section should be structured as a series of
+> problems and their solutions, with the most common problems listed
+> first.
+
+> The audience for this section is oncall and ticket handlers (onduty, interrupts).
+
+> If a playbook for alert handling exists, link to that as well.
+
+Software Summary {#software_summary}
+----------------
+
+> What software packages are used to run this service? Which version do we
+> run? Please indicate the kernel requirements, if the service has special
+> needs.
+
+See [Software Requirements](build.md#software_requirements).
+
+### Configuration Files or Settings {#config_files}
+
+> What configuration files or settings exist and where are the located?
+> How do you make changes to these configurations if needed? Provide links
+> to other documents, also link scripts for scheduled automated tasks, if
+> needed.
+
+@YOUR_ORG@ Implementation {#impl}
+------------------------
+
+> Provide a short description of how this service is implemented at
+> @YOUR_ORG@. If applicable, try to include a graphic to show connections
+> among system components. If it is not possible to describe the service
+> architecture in a few paragraphs, then please link to an external
+> architecture document.
+
+> Bonus points for graphviz diagrams.
+
+> What changes have been made to the upstream version if any?
+
+
+
+### Data/Query Flow {#data_flow}
+
+> Be sure to indicate the data flow that occurs when a user accesses the
+> service. If there is an autopush mechanism for configuration files,
+> explain how this works.
+
+> Bonus points for graphviz diagrams.
+
+Servers/Hardware {#servers_hardware}
+----------------
+
+> What servers does this service run on? Are there multiple servers, replicas,
+> and/or VIPs? Where are the servers (physically) located (or provide
+> link to a physical location list for servers)?
+
+> Is console access configured? Does it have a serial connection?
+
+### Global Replication {#global_replication}
+
+> How is this service be replicated?
+
+Scheduled Manual Tasks {#sched_man_tasks}
+----------------------
+
+> Are there any routine tasks that need to be done manually for this
+> service? For example, if this service needs periodic gardening
+> tasks such as patching or performance checks, what specifically needs to be
+> done and how often?
+
+Scheduled Automated Tasks {#sched_auto_tasks}
+-------------------------
+
+> What automated jobs are related to this service. What do they do, what
+> server(s) do they run on, as what user, and how often? Are there
+> internal automated processes associated with this service? Are there any
+> automatic configuration pushes?  If they're monitored, can we see that they're all functioning correctly?
+
+### Backups
+
+> What backups need to be done on the local server machine?
+> How do we verify restores work?
+
+Monitoring {#monitoring}
+-------
+
+> Is there a place to make adhoc queries about the behaviour of the serviec?  Is there a place to make pre-cooked queries?
+> If so, link to the source code for the dashboards and precomputed queries.
+
+### Logs
+
+> Where are errors for the service/function reported and where are the
+> files located? Is any other information logged? If this service
+> generates log files, how are they rotated? Is it supported by syslog-ng?
+> Describe any known issues that can be diagnosed by viewing the logs, and
+> explain how to fix them.
+
+### Metrics, probes, alerts
+
+> What sort of monitoring is done for this service?
+> Include links to relevant dashboards and alertmanager ilnks.
+
+### Traces
+
+> Does the service generate trace samples? Where can I see them?
+
+Vendors
+-------
+
+> Do we have vendor relationships with the hardware or software providers of
+> this service? If so, please link to contact information here, or if there's a
+> central vendor register, then link to that.

--- a/service_docs/templates/security.md
+++ b/service_docs/templates/security.md
@@ -1,0 +1,102 @@
+[Home](index.md) [Operations](operations.md) [Build](build.md) [DR](disaster_recovery.md) [Common Tasks](common_tasks.md) [Security](security.md)
+
+Last Update: @Date@
+
+> Replace this note with your own customisation.
+
+**Note:** This document is meant for Ops, Helpdesk, or Security. If you are
+having problems with a service, please call Helpdesk or
+[file a ticket](@TICKET_URL@).
+
+@SERVICE_NAME@ Security
+========================================
+
+
+**Quick links:**
+
+-   [Server locations](oeprations.md#servers_hardware)
+-   [Troubleshooting information](operations.md#troubleshooting)
+
+
+------------------------------------------------------------------------
+
+This document gives a machine- or node-level view of the access controls in
+place for the service. Its intended audience includes service owners, Security,
+and Ops.
+
+Description
+-----------
+
+> Describe the purpose of the service, whether it involves sensitive
+> information and if so, what type. Then describe, from a high-level, who
+> should have access, and generally how that access is controlled.
+
+### Applications and Hosts
+
+Applications, processes and services that run in this pod are as
+follows.
+
+See the [Software Requirements](build.md#software_requirements) and [Roles](build.md#roles).
+
+> Also describe any special constraints on where these machines are
+> physically located or how they are protected. For example, does this
+> service involve sensitive data? Do the machines need to be placed within
+> locked cabinets? What datacenters currently house this service?
+
+See the [Physical Location](build.md#location).
+
+> What is the (extended) perimeter of the service -- does it include load balancers for access control to the normal interfaces?
+
+### Roles and Access {#access_policy}
+
+> The full set of roles characterizing everyone who has access to the service.
+> Use actual group names from AD/LDAP or mailing list as appropriate with links to their definitions.
+
+> How do people request and gain access to these roles?
+
+Overview
+------------
+
+### Data Flow
+
+See [Data Flow](operations.md#data_flow).
+
+### Locations
+
+See [Locations](operations.md#servers_hardware).
+
+### Environments
+
+> Is there a separate infrastructure for purposes like development or
+> testing? Do these have require access to sensitive data and require
+> similar access restrictions as the production environment?
+
+### Network
+
+> What is the general network layout for this system?
+
+Access Controls
+-------------------
+
+This section describes all of the policies in place that restrict access
+to the service.
+
+To request any type of access to the service, see the [Access Policy](#access_policy).
+
+> ### Access Control Mechanism 1
+>
+> For each major type of mechanism (e.g. login policy, firewall) in place to
+> restrict access to this service include a subsection.  In general, access
+> restrictions should be described and implemented by roles listed above. If
+> access controls are not readable and/or updated by the methods described
+> above, note the specialisation here.
+>
+> In line with the principle of defence in depth, aim for an access control
+> mechanism at each layer of the networking stack
+
+
+Activity Monitoring
+-------------------
+
+> Describe how we collect information for audits that check if our
+> security controls are working.


### PR DESCRIPTION
This is a version of the Sysops `ops100` templates used for documenting
services for oncallers, ticketeers (aka onduty or interrupts), helpdesk, and
service teams.